### PR TITLE
Add a simple retry for the rest client calls

### DIFF
--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClient.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClient.java
@@ -156,7 +156,7 @@ public interface JiraRestClient {
 			return new JiraRestException(
 					"Encountered an error calling Jira REST API: %s resulting in: %s".formatted(uri,
 							response.hasEntity() ? response.readEntity(String.class) : "No response body"),
-					response.getStatus());
+					response.getStatus(), response.getHeaders());
 		}
 		return null;
 	}

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestException.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestException.java
@@ -1,14 +1,23 @@
 package org.hibernate.infra.replicate.jira.service.jira.client;
 
+import java.util.List;
+import java.util.Map;
+
 public class JiraRestException extends RuntimeException {
 	private final int statusCode;
+	private final Map<String, List<Object>> headers;
 
-	public JiraRestException(String message, int statusCode) {
+	public JiraRestException(String message, int statusCode, Map<String, List<Object>> headers) {
 		super(message);
 		this.statusCode = statusCode;
+		this.headers = headers;
 	}
 
 	public int statusCode() {
 		return statusCode;
+	}
+
+	public Map<String, List<Object>> headers() {
+		return headers;
 	}
 }

--- a/src/test/java/org/hibernate/infra/replicate/jira/mock/SampleJiraRestClient.java
+++ b/src/test/java/org/hibernate/infra/replicate/jira/mock/SampleJiraRestClient.java
@@ -2,6 +2,7 @@ package org.hibernate.infra.replicate.jira.mock;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,7 +42,7 @@ public class SampleJiraRestClient implements JiraRestClient {
 	@Override
 	public JiraIssue getIssue(String key) {
 		if (Pattern.compile(itemCannotBeFound.get()).matcher(key).matches()) {
-			throw new JiraRestException("No issue %s".formatted(key), 404);
+			throw new JiraRestException("No issue %s".formatted(key), 404, Map.of());
 		}
 		return sample(1L, key);
 	}
@@ -49,7 +50,7 @@ public class SampleJiraRestClient implements JiraRestClient {
 	@Override
 	public JiraIssue getIssue(Long id) {
 		if (Pattern.compile(itemCannotBeFound.get()).matcher(Long.toString(id)).matches()) {
-			throw new JiraRestException("No issue %s".formatted(id), 404);
+			throw new JiraRestException("No issue %s".formatted(id), 404, Map.of());
 		}
 		return sample(id, jiraKey(id));
 	}
@@ -87,7 +88,7 @@ public class SampleJiraRestClient implements JiraRestClient {
 	@Override
 	public JiraComment getComment(Long issueId, Long commentId) {
 		if (Pattern.compile(itemCannotBeFound.get()).matcher("%d - %d".formatted(issueId, commentId)).matches()) {
-			throw new JiraRestException("No comment %s".formatted(commentId), 404);
+			throw new JiraRestException("No comment %s".formatted(commentId), 404, Map.of());
 		}
 		return sampleComment(issueId, commentId);
 	}
@@ -177,7 +178,9 @@ public class SampleJiraRestClient implements JiraRestClient {
 
 	@Override
 	public JiraIssues find(String query, int startAt, int maxResults) {
-		return new JiraIssues();
+		JiraIssues issues = new JiraIssues();
+		issues.issues = List.of();
+		return issues;
 	}
 
 	@Override


### PR DESCRIPTION
https://quarkus.io/guides/smallrye-fault-tolerance#adding-resiliency-retries

^ This doesn't play with a programmatic rest client 😖. Hence, in this PR, I've just wrapped the built client in a retry-wrapper...