### PR TITLE
Try updating an issue without an assignee if the inital request failed

### DIFF
--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/JiraService.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/JiraService.java
@@ -139,6 +139,21 @@ public class JiraService {
 					}).schedule();
 			rc.end();
 		});
+		mi.router().get("/sync/issues/re-sync/:project/:issue").blockingHandler(rc -> {
+			// TODO: we can remove this one once we figure out why POST management does not
+			// work correctly...
+			String project = rc.pathParam("project");
+			String issue = rc.pathParam("issue");
+
+			HandlerProjectContext context = contextPerProject.get(project);
+
+			if (context == null) {
+				throw new IllegalArgumentException("Unknown project '%s'".formatted(project));
+			}
+
+			triggerSyncEvent(context.sourceJiraClient().getIssue(issue), context);
+			rc.end();
+		});
 		mi.router().post("/sync/issues/list").consumes(MediaType.APPLICATION_JSON).blockingHandler(rc -> {
 			// sync issues based on a list of issue-keys supplied in the JSON body:
 			JsonObject request = rc.body().asJsonObject();

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClientBuilder.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClientBuilder.java
@@ -154,7 +154,8 @@ public class JiraRestClientBuilder {
 
 		@Override
 		public JiraIssueResponse update(String key, JiraIssue issue) {
-			return withRetry(() -> delegate.update(key, issue));
+			// it might be that mapped user is wrong so we don't want to keep sending it
+			return withRetry( () -> delegate.update( key, issue ), 2 );
 		}
 
 		@Override
@@ -258,8 +259,12 @@ public class JiraRestClientBuilder {
 		}
 
 		private <T> T withRetry(Supplier<T> supplier) {
+			return withRetry( supplier, RETRIES );
+		}
+
+		private <T> T withRetry(Supplier<T> supplier, int retries) {
 			RuntimeException e = null;
-			for (int i = 0; i < RETRIES; i++) {
+			for (int i = 0; i < retries; i++) {
 				try {
 					return supplier.get();
 				} catch (RuntimeException exception) {

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClientBuilder.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClientBuilder.java
@@ -258,6 +258,7 @@ public class JiraRestClientBuilder {
 		}
 
 		private <T> T withRetry(Supplier<T> supplier) {
+			RuntimeException e = null;
 			for (int i = 0; i < RETRIES; i++) {
 				try {
 					return supplier.get();
@@ -265,14 +266,15 @@ public class JiraRestClientBuilder {
 					if (!shouldRetryOnException(exception)) {
 						throw exception;
 					}
+					e = exception;
 				}
 				try {
 					Thread.sleep(WAIT_BETWEEN_RETRIES);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException exception) {
 					Thread.currentThread().interrupt();
 				}
 			}
-			throw new IllegalStateException("Shouldn't really reach this far.");
+			throw e;
 		}
 
 		private boolean shouldRetryOnException(Throwable throwable) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,7 +61,7 @@ quarkus.scheduler.start-mode=forced
 %prod,test.jira.project-group."hibernate".users.mapping."712020\:dcf258b4-84bc-4e85-a34f-054b5ac2d0d1"=mbellade
 %prod,test.jira.project-group."hibernate".users.mapping."637b480e9e48f2b9a6119795"=mbellade
 # Guillaume
-%prod,test.jira.project-group."hibernate".users.mapping."557058\:71e31052-f0d7-46e3-a9d7-8b9acd6998d8"=guillaume.smet
+%prod,test.jira.project-group."hibernate".users.mapping."557058\:71e31052-f0d7-46e3-a9d7-8b9acd6998d8"=gsmet@redhat.com
 ## Gunnar
 #%prod,test.jira.project-group."hibernate".users.mapping."557058\:6a9959ae-3b15-4370-ad41-e78c978f4f7b"=gunnar.morling
 ## Sanne


### PR DESCRIPTION
It might be that the user is inactive or misconfigured. If the response points to a problem with an assignee let's try updating the issue itself without it.