### PR TITLE
Set not-mapped-assignee only when the assignee is actually present but not mapped

### DIFF
--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueAbstractEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueAbstractEventHandler.java
@@ -118,8 +118,10 @@ abstract class JiraIssueAbstractEventHandler extends JiraEventHandler {
 			destinationIssue.fields.reporter = user(sourceIssue.fields.reporter).map(this::toUser).orElse(null);
 		}
 
-		destinationIssue.fields.assignee = user(sourceIssue.fields.assignee).map(this::toUser)
-				.orElseGet(context::notMappedAssignee);
+		if (sourceIssue.fields.assignee != null) {
+			destinationIssue.fields.assignee = user(sourceIssue.fields.assignee).map(this::toUser)
+					.orElseGet(context::notMappedAssignee);
+		}
 
 		return destinationIssue;
 	}


### PR DESCRIPTION
Because otherwise we would end up setting the not-mapped one for "unassigned" as well