### PR TITLE
Specify route host and path to use an infra url

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,6 +48,12 @@ quarkus.openshift.startup-probe.failure-threshold=48
 quarkus.openshift.ports."management".container-port=9000
 quarkus.openshift.ports."management".host-port=90
 # Add routes:
+quarkus.openshift.route.host=infra.hibernate.org
+quarkus.openshift.route.path=/replicate-jira
+# Use a rewrite target so that the request go to the app root and the app handles the remaining path
+# otherwise the app will end up receiving the path starting with `quarkus.openshift.route.path` (see ^)
+# which it has no idea how to handle:
+quarkus.openshift.route.annotations."haproxy.router.openshift.io/rewrite-target"=/
 quarkus.openshift.route.expose=true
 quarkus.openshift.route.target-port=http
 ## Route TLS configuration:


### PR DESCRIPTION
I couldn't find how to add multiple routes (https://quarkus.io/guides/deploying-to-openshift)... so I guess I'll create a "default" route manually after deploying so we have time to change the hook 