### PR TITLE
Use project group context for handling events

### DIFF
--- a/src/main/java/org/hibernate/infra/replicate/jira/JiraConfig.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/JiraConfig.java
@@ -98,6 +98,11 @@ public interface JiraConfig {
 		 * Allows customizing formatting options.
 		 */
 		Formatting formatting();
+
+		/**
+		 * Allows enabling signature verification.
+		 */
+		WebHookSecurity security();
 	}
 
 	interface Formatting {
@@ -187,11 +192,6 @@ public interface JiraConfig {
 		 * the info.
 		 */
 		String originalProjectKey();
-
-		/**
-		 * Allows enabling signature verification.
-		 */
-		WebHookSecurity security();
 
 		/**
 		 * Allows enabling signature verification of downstream events.

--- a/src/main/java/org/hibernate/infra/replicate/jira/resource/JiraWebHookListenerResource.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/resource/JiraWebHookListenerResource.java
@@ -4,6 +4,7 @@ import org.hibernate.infra.replicate.jira.service.jira.JiraService;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
 import org.hibernate.infra.replicate.jira.service.jira.model.hook.JiraWebHookEvent;
 import org.hibernate.infra.replicate.jira.service.validation.ConfiguredProject;
+import org.hibernate.infra.replicate.jira.service.validation.ConfiguredProjectGroup;
 
 import org.jboss.resteasy.reactive.RestPath;
 
@@ -23,22 +24,22 @@ public class JiraWebHookListenerResource {
 	JiraService jiraService;
 
 	@POST
-	@Path("/{project}")
+	@Path("/source/{projectGroup}")
 	@Consumes(MediaType.APPLICATION_JSON)
-	public String somethingHappenedUpstream(@RestPath @NotNull @ConfiguredProject String project,
+	public String somethingHappenedUpstream(@RestPath @NotNull @ConfiguredProjectGroup String projectGroup,
 			@QueryParam("triggeredByUser") String triggeredByUser, JiraWebHookEvent event) {
-		Log.tracef("Received a notification about %s project: %.200s...", project, event);
-		jiraService.acknowledge(project, event, triggeredByUser);
+		Log.tracef("Received a notification about %s project group: %.200s...", projectGroup, event);
+		jiraService.acknowledge(projectGroup, event, triggeredByUser);
 		return "ack";
 	}
 
 	@POST
-	@Path("/mirror/{project}")
+	@Path("/mirror/{projectGroup}/{project}")
 	@Consumes(MediaType.APPLICATION_JSON)
-	public String somethingHappenedDownstream(@RestPath @NotNull @ConfiguredProject String project,
-			JiraActionEvent data) {
+	public String somethingHappenedDownstream(@RestPath @NotNull @ConfiguredProjectGroup String projectGroup,
+			@RestPath @NotNull @ConfiguredProject String project, JiraActionEvent data) {
 		Log.tracef("Received a downstream notification about %s project: %s...", project, data);
-		jiraService.downstreamAcknowledge(project, data);
+		jiraService.downstreamAcknowledge(projectGroup, data);
 		return "ack";
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/HandlerProjectGroupContext.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/HandlerProjectGroupContext.java
@@ -1,8 +1,11 @@
 package org.hibernate.infra.replicate.jira.service.jira;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -11,8 +14,11 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import org.hibernate.infra.replicate.jira.JiraConfig;
+import org.hibernate.infra.replicate.jira.service.jira.client.JiraRestClient;
+import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraUser;
 
 import io.quarkus.logging.Log;
 
@@ -20,6 +26,10 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 
 	private final ExecutorService eventHandlingExecutor;
 	private final Supplier<Integer> workQueueSize;
+
+	private final String projectGroupName;
+	private final JiraRestClient sourceJiraClient;
+	private final JiraRestClient destinationJiraClient;
 
 	private final ExecutorService downstreamEventHandlingExecutor;
 	private final Supplier<Integer> downstreamWorkQueueSize;
@@ -29,8 +39,14 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 	private final JiraConfig.JiraProjectGroup projectGroup;
 	private final Map<String, String> invertedUsers;
 	private final Map<String, String> invertedStatuses;
+	private final Map<String, HandlerProjectContext> projectContexts;
+	private final Pattern sourceLabelPattern;
+	private final JiraUser notMappedAssignee;
+	private final DateTimeFormatter formatter;
 
-	public HandlerProjectGroupContext(JiraConfig.JiraProjectGroup projectGroup) {
+	public HandlerProjectGroupContext(String projectGroupName, JiraConfig.JiraProjectGroup projectGroup,
+			JiraRestClient source, JiraRestClient destination) {
+		this.projectGroupName = projectGroupName;
 		this.projectGroup = projectGroup;
 
 		JiraConfig.EventProcessing processing = projectGroup.processing();
@@ -57,6 +73,21 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 
 		this.invertedUsers = invert(projectGroup.users().mapping());
 		this.invertedStatuses = invert(projectGroup.statuses().mapping());
+		this.sourceJiraClient = source;
+		this.destinationJiraClient = destination;
+
+		Map<String, HandlerProjectContext> projectContexts = new HashMap<>();
+
+		for (var project : projectGroup.projects().entrySet()) {
+			projectContexts.put(project.getKey(), new HandlerProjectContext(project.getKey(), this));
+		}
+		this.projectContexts = Collections.unmodifiableMap(projectContexts);
+
+		this.notMappedAssignee = projectGroup().users().notMappedAssignee()
+				.map(v -> new JiraUser(projectGroup().users().mappedPropertyName(), v)).orElse(null);
+
+		this.sourceLabelPattern = Pattern.compile(projectGroup().formatting().labelTemplate().formatted(".+"));
+		this.formatter = DateTimeFormatter.ofPattern(projectGroup().formatting().timestampFormat());
 	}
 
 	private static Map<String, String> invert(Map<String, String> map) {
@@ -73,6 +104,10 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 
 	public void startProcessingDownstreamEvent() throws InterruptedException {
 		downstreamRateLimiter.acquire(1);
+	}
+
+	public String projectGroupName() {
+		return projectGroupName;
 	}
 
 	public JiraConfig.JiraProjectGroup projectGroup() {
@@ -95,8 +130,55 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 		downstreamEventHandlingExecutor.submit(task);
 	}
 
+	public JiraRestClient sourceJiraClient() {
+		return sourceJiraClient;
+	}
+
+	public JiraRestClient destinationJiraClient() {
+		return destinationJiraClient;
+	}
+
+	public HandlerProjectContext contextForProject(String project) {
+		HandlerProjectContext context = projectContexts.get(project);
+		if (context == null) {
+			throw new IllegalStateException("No handler context for project %s".formatted(project));
+		}
+		return context;
+	}
+
+	public Optional<HandlerProjectContext> findContextForProject(String project) {
+		if (!projectGroup().projects().containsKey(project)) {
+			// different project group, don't bother
+			return Optional.empty();
+		}
+		return Optional.ofNullable(projectContexts.get(project));
+	}
+
+	public Optional<HandlerProjectContext> findContextForOriginalProjectKey(String project) {
+
+		for (HandlerProjectContext context : projectContexts.values()) {
+			if (context.project().originalProjectKey().equals(project)) {
+				return Optional.of(context);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	public HandlerProjectContext contextForOriginalProjectKey(String project) {
+
+		for (HandlerProjectContext context : projectContexts.values()) {
+			if (context.project().originalProjectKey().equals(project)) {
+				return context;
+			}
+		}
+
+		throw new IllegalStateException("No handler context for project %s".formatted(project));
+	}
+
 	@Override
 	public void close() {
+		projectContexts.values().forEach(HandlerProjectContext::close);
 		// when requesting to close the context we aren't expecting to process any other
 		// events hence there's no point in continuing "releasing" more "permits":
 		if (!rateLimiterExecutor.isShutdown()) {
@@ -125,6 +207,26 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 
 	public String upstreamStatus(String mappedValue) {
 		return invertedStatuses.get(mappedValue);
+	}
+
+	public boolean isUserIgnored(String triggeredByUser) {
+		return projectGroup().users().ignoredUpstreamUsers().contains(triggeredByUser);
+	}
+
+	public boolean isDownstreamUserIgnored(String triggeredByUser) {
+		return projectGroup().users().ignoredDownstreamUsers().contains(triggeredByUser);
+	}
+
+	public JiraUser notMappedAssignee() {
+		return notMappedAssignee;
+	}
+
+	public boolean isSourceLabel(String label) {
+		return sourceLabelPattern.matcher(label).matches();
+	}
+
+	public String formatTimestamp(ZonedDateTime time) {
+		return time != null ? time.format(formatter) : "";
 	}
 
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClient.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClient.java
@@ -12,6 +12,7 @@ import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueLink;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueLinkTypes;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueResponse;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssues;
+import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraProject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraRemoteLink;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraSimpleObject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraTransition;
@@ -176,6 +177,10 @@ public interface JiraRestClient {
 	@PUT
 	@Path("/issue/{issueKey}/assignee")
 	void assign(@PathParam("issueKey") String id, JiraUser assignee);
+
+	@GET
+	@Path("/project/{projectId}")
+	JiraProject project(String projectId);
 
 	@ClientObjectMapper
 	static ObjectMapper objectMapper(ObjectMapper defaultObjectMapper) {

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClientBuilder.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/client/JiraRestClientBuilder.java
@@ -18,6 +18,7 @@ import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueLink;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueLinkTypes;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueResponse;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssues;
+import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraProject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraRemoteLink;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraSimpleObject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraTransition;
@@ -284,6 +285,11 @@ public class JiraRestClientBuilder {
 		@Override
 		public void assign(String id, JiraUser assignee) {
 			withRetry(() -> delegate.assign(id, assignee));
+		}
+
+		@Override
+		public JiraProject project(String projectId) {
+			return withRetry(() -> delegate.project(projectId));
 		}
 
 		private static final int RETRIES = 5;

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraCommentDeleteEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraCommentDeleteEventHandler.java
@@ -2,7 +2,7 @@ package org.hibernate.infra.replicate.jira.service.jira.handler;
 
 import java.util.Optional;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.client.JiraRestException;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComment;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComments;
@@ -10,15 +10,16 @@ import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraCommentDeleteEventHandler extends JiraCommentEventHandler {
-	public JiraCommentDeleteEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long commentId,
-			Long issueId) {
+	public JiraCommentDeleteEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
+			Long commentId, Long issueId) {
 		super(reportingConfig, context, commentId, issueId);
 	}
 
 	@Override
 	protected void doRun() {
 		JiraIssue issue = context.sourceJiraClient().getIssue(issueId);
-		String destinationKey = toDestinationKey(issue.key);
+		String destinationKey = context.contextForOriginalProjectKey(toProjectFromKey(issue.key))
+				.toDestinationKey(issue.key);
 		try {
 			JiraComment comment = context.sourceJiraClient().getComment(issueId, objectId);
 		} catch (JiraRestException e) {
@@ -39,7 +40,7 @@ public class JiraCommentDeleteEventHandler extends JiraCommentEventHandler {
 
 	@Override
 	public String toString() {
-		return "JiraCommentDeleteEventHandler[" + "issueId=" + issueId + ", objectId=" + objectId + ", project="
-				+ context.projectName() + ']';
+		return "JiraCommentDeleteEventHandler[" + "issueId=" + issueId + ", objectId=" + objectId + ", projectGroup="
+				+ context.projectGroupName() + ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraCommentEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraCommentEventHandler.java
@@ -3,7 +3,7 @@ package org.hibernate.infra.replicate.jira.service.jira.handler;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComment;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComments;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
@@ -15,7 +15,7 @@ abstract class JiraCommentEventHandler extends JiraEventHandler {
 
 	protected final Long issueId;
 
-	public JiraCommentEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long commentId,
+	public JiraCommentEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context, Long commentId,
 			Long issueId) {
 		super(reportingConfig, context, commentId);
 		this.issueId = issueId;

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraCommentUpsertEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraCommentUpsertEventHandler.java
@@ -3,7 +3,7 @@ package org.hibernate.infra.replicate.jira.service.jira.handler;
 import java.net.URI;
 import java.util.Optional;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.client.JiraRestException;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComment;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComments;
@@ -12,8 +12,8 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraCommentUpsertEventHandler extends JiraCommentEventHandler {
 
-	public JiraCommentUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long commentId,
-			Long issueId) {
+	public JiraCommentUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
+			Long commentId, Long issueId) {
 		super(reportingConfig, context, commentId, issueId);
 	}
 
@@ -22,7 +22,8 @@ public class JiraCommentUpsertEventHandler extends JiraCommentEventHandler {
 		JiraIssue issue = context.sourceJiraClient().getIssue(issueId);
 		JiraComment comment = context.sourceJiraClient().getComment(issueId, objectId);
 
-		String destinationKey = toDestinationKey(issue.key);
+		String destinationKey = context.contextForOriginalProjectKey(toProjectFromKey(issue.key))
+				.toDestinationKey(issue.key);
 
 		// We are going to assume that the Jira issue was already synced downstream,
 		// and try to find its comments. If the issue is not yet there, then we'll just
@@ -75,7 +76,7 @@ public class JiraCommentUpsertEventHandler extends JiraCommentEventHandler {
 
 	@Override
 	public String toString() {
-		return "JiraCommentUpsertEventHandler[" + "issueId=" + issueId + ", objectId=" + objectId + ", project="
-				+ context.projectName() + ']';
+		return "JiraCommentUpsertEventHandler[" + "issueId=" + issueId + ", objectId=" + objectId + ", projectGroup="
+				+ context.projectGroupName() + ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraEventHandler.java
@@ -6,10 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import org.hibernate.infra.replicate.jira.JiraConfig;
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraComment;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraSimpleObject;
@@ -26,14 +25,12 @@ public abstract class JiraEventHandler implements Runnable {
 
 	protected final Long objectId;
 	protected final FailureCollector failureCollector;
-	protected final HandlerProjectContext context;
-	private final Pattern keyToUpdatePattern;
+	protected final HandlerProjectGroupContext context;
 
-	protected JiraEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long id) {
+	protected JiraEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context, Long id) {
 		this.objectId = id;
 		this.failureCollector = FailureCollector.collector(reportingConfig);
 		this.context = context;
-		this.keyToUpdatePattern = Pattern.compile("^%s-\\d+".formatted(context.project().originalProjectKey()));
 	}
 
 	protected static URI createJiraIssueUri(JiraIssue sourceIssue) {
@@ -201,13 +198,6 @@ public abstract class JiraEventHandler implements Runnable {
 			content = content.substring(0, MAX_CONTENT_SIZE);
 		}
 		return content;
-	}
-
-	protected String toDestinationKey(String key) {
-		if (keyToUpdatePattern.matcher(key).matches()) {
-			return "%s-%d".formatted(context.project().projectKey(), JiraIssue.keyToLong(key));
-		}
-		return key;
 	}
 
 	protected String toProjectFromKey(String key) {

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueDeleteEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueDeleteEventHandler.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.client.JiraRestException;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraFields;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
@@ -18,7 +18,7 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 public class JiraIssueDeleteEventHandler extends JiraIssueAbstractEventHandler {
 	private final String key;
 
-	public JiraIssueDeleteEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long id,
+	public JiraIssueDeleteEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context, Long id,
 			String key) {
 		super(reportingConfig, context, id);
 		this.key = key;
@@ -52,7 +52,7 @@ public class JiraIssueDeleteEventHandler extends JiraIssueAbstractEventHandler {
 
 	private void handleDeletedMovedIssue(String type) {
 		try {
-			String destinationKey = toDestinationKey(key);
+			String destinationKey = context.contextForOriginalProjectKey(toProjectFromKey(key)).toDestinationKey(key);
 			JiraIssue issue = context.destinationJiraClient().getIssue(destinationKey);
 			JiraIssue updated = new JiraIssue();
 
@@ -99,7 +99,7 @@ public class JiraIssueDeleteEventHandler extends JiraIssueAbstractEventHandler {
 
 	@Override
 	public String toString() {
-		return "JiraIssueDeleteEventHandler[" + "key='" + key + '\'' + ", objectId=" + objectId + ", project="
-				+ context.projectName() + ']';
+		return "JiraIssueDeleteEventHandler[" + "key='" + key + '\'' + ", objectId=" + objectId + ", projectGroup="
+				+ context.projectGroupName() + ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueInternalAbstractEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueInternalAbstractEventHandler.java
@@ -1,6 +1,7 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler;
 
 import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.client.JiraRestException;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
@@ -9,7 +10,7 @@ abstract class JiraIssueInternalAbstractEventHandler extends JiraIssueAbstractEv
 
 	private final JiraIssue sourceIssue;
 
-	protected JiraIssueInternalAbstractEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	protected JiraIssueInternalAbstractEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraIssue issue) {
 		super(reportingConfig, context, issue.id);
 		this.sourceIssue = issue;
@@ -19,20 +20,22 @@ abstract class JiraIssueInternalAbstractEventHandler extends JiraIssueAbstractEv
 	protected final void doRun() {
 		// NOTE: we do not look up the source issue as we've already queried for it
 		// before creating this handler:
-		String destinationKey = toDestinationKey(sourceIssue.key);
+		HandlerProjectContext projectContext = context.contextForOriginalProjectKey(sourceIssue.fields.project.key);
+		String destinationKey = projectContext.toDestinationKey(sourceIssue.key);
 		// We don't really need one, but doing so means that we will create the
 		// placeholder for it if the issue wasn't already present in the destination
 		// Jira instance
-		context.createNextPlaceholderBatch(destinationKey);
+		projectContext.createNextPlaceholderBatch(destinationKey);
 
 		try {
-			updateAction(destinationKey, sourceIssue);
+			updateAction(projectContext, destinationKey, sourceIssue);
 		} catch (JiraRestException e) {
 			failureCollector
 					.critical("Unable to update destination issue %s: %s".formatted(destinationKey, e.getMessage()), e);
 		}
 	}
 
-	protected abstract void updateAction(String destinationKey, JiraIssue sourceIssue);
+	protected abstract void updateAction(HandlerProjectContext projectContext, String destinationKey,
+			JiraIssue sourceIssue);
 
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueLinkDeleteEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueLinkDeleteEventHandler.java
@@ -1,6 +1,6 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.client.JiraRestException;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueLink;
@@ -11,7 +11,8 @@ public class JiraIssueLinkDeleteEventHandler extends JiraEventHandler {
 
 	private final Long destinationIssueId;
 	private final String issueLinkTypeId;
-	public JiraIssueLinkDeleteEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long id,
+
+	public JiraIssueLinkDeleteEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context, Long id,
 			Long sourceIssueId, Long destinationIssueId, String issueLinkTypeId) {
 		super(reportingConfig, context, id);
 		this.sourceIssueId = sourceIssueId;
@@ -46,8 +47,10 @@ public class JiraIssueLinkDeleteEventHandler extends JiraEventHandler {
 		}
 
 		// make sure that both sides of the link exist:
-		String outwardIssue = toDestinationKey(sourceIssue.key);
-		String inwardIssue = toDestinationKey(destinationIssue.key);
+		String outwardIssue = context.contextForOriginalProjectKey(toProjectFromKey(sourceIssue.key))
+				.toDestinationKey(sourceIssue.key);
+		String inwardIssue = context.contextForOriginalProjectKey(toProjectFromKey(destinationIssue.key))
+				.toDestinationKey(destinationIssue.key);
 		// we will let it fail if one issue does not exist as that would mean that the
 		// link is also not there:
 		context.destinationJiraClient().getIssue(outwardIssue);
@@ -68,7 +71,7 @@ public class JiraIssueLinkDeleteEventHandler extends JiraEventHandler {
 	@Override
 	public String toString() {
 		return "JiraIssueLinkDeleteEventHandler[" + "sourceIssueId=" + sourceIssueId + ", destinationIssueId="
-				+ destinationIssueId + ", issueLinkTypeId='" + issueLinkTypeId + '\'' + ", project="
-				+ context.projectName() + ']';
+				+ destinationIssueId + ", issueLinkTypeId='" + issueLinkTypeId + '\'' + ", projectGroup="
+				+ context.projectGroupName() + ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueSimpleUpsertEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueSimpleUpsertEventHandler.java
@@ -1,6 +1,7 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler;
 
 import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
@@ -8,21 +9,21 @@ public class JiraIssueSimpleUpsertEventHandler extends JiraIssueInternalAbstract
 
 	private final boolean applyTransitionUpdate;
 
-	public JiraIssueSimpleUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraIssueSimpleUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraIssue issue) {
 		this(reportingConfig, context, issue, false);
 	}
 
-	public JiraIssueSimpleUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraIssueSimpleUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraIssue issue, boolean applyTransitionUpdate) {
 		super(reportingConfig, context, issue);
 		this.applyTransitionUpdate = applyTransitionUpdate;
 	}
 
 	@Override
-	protected void updateAction(String destinationKey, JiraIssue sourceIssue) {
+	protected void updateAction(HandlerProjectContext projectContext, String destinationKey, JiraIssue sourceIssue) {
 		JiraIssue destIssue = context.destinationJiraClient().getIssue(destinationKey);
-		updateIssueBody(sourceIssue, destIssue, destinationKey);
+		updateIssueBody(projectContext, sourceIssue, destIssue, destinationKey);
 		if (applyTransitionUpdate) {
 			applyTransition(sourceIssue, destIssue, destinationKey);
 		}
@@ -30,7 +31,7 @@ public class JiraIssueSimpleUpsertEventHandler extends JiraIssueInternalAbstract
 
 	@Override
 	public String toString() {
-		return "JiraIssueSimpleUpsertEventHandler[" + "objectId=" + objectId + ", project=" + context.projectName()
-				+ ']';
+		return "JiraIssueSimpleUpsertEventHandler[" + "objectId=" + objectId + ", projectGroup="
+				+ context.projectGroupName() + ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueTransitionOnlyEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraIssueTransitionOnlyEventHandler.java
@@ -1,24 +1,25 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler;
 
 import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraIssueTransitionOnlyEventHandler extends JiraIssueInternalAbstractEventHandler {
 
-	public JiraIssueTransitionOnlyEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraIssueTransitionOnlyEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraIssue issue) {
 		super(reportingConfig, context, issue);
 	}
 
 	@Override
-	protected void updateAction(String destinationKey, JiraIssue sourceIssue) {
+	protected void updateAction(HandlerProjectContext projectContext, String destinationKey, JiraIssue sourceIssue) {
 		applyTransition(sourceIssue, destinationKey);
 	}
 
 	@Override
 	public String toString() {
-		return "JiraIssueTransitionOnlyEventHandler[" + "objectId=" + objectId + ", project=" + context.projectName()
-				+ ']';
+		return "JiraIssueTransitionOnlyEventHandler[" + "objectId=" + objectId + ", projectGroup="
+				+ context.projectGroupName() + ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraVersionUpsertEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/JiraVersionUpsertEventHandler.java
@@ -1,19 +1,21 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
+import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraProject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraVersion;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraVersionUpsertEventHandler extends JiraEventHandler {
 
-	public JiraVersionUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context, Long id) {
+	public JiraVersionUpsertEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context, Long id) {
 		super(reportingConfig, context, id);
 	}
 
 	@Override
 	protected void doRun() {
 		JiraVersion version = context.sourceJiraClient().version(objectId);
-		context.fixVersion(version, true);
+		JiraProject project = context.sourceJiraClient().project(version.projectId);
+		context.findContextForOriginalProjectKey(project.key).get().fixVersion(version, true);
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraAbstractVersionActionEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraAbstractVersionActionEventHandler.java
@@ -3,7 +3,7 @@ package org.hibernate.infra.replicate.jira.service.jira.handler.action;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraFields;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
@@ -12,7 +12,7 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 abstract class JiraAbstractVersionActionEventHandler extends JiraActionEventHandler {
 
-	public JiraAbstractVersionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraAbstractVersionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraActionEvent event) {
 		super(reportingConfig, context, event);
 	}
@@ -40,7 +40,7 @@ abstract class JiraAbstractVersionActionEventHandler extends JiraActionEventHand
 
 		setVersionList(updated, versions);
 
-		context.sourceJiraClient().update(toSourceKey(event.key), updated);
+		context.sourceJiraClient().update(context.contextForProject(event.projectKey).toSourceKey(event.key), updated);
 	}
 
 	protected abstract void setVersionList(JiraIssue issue, List<JiraVersion> versions);
@@ -49,6 +49,7 @@ abstract class JiraAbstractVersionActionEventHandler extends JiraActionEventHand
 
 	@Override
 	public String toString() {
-		return this.getClass().getSimpleName() + "[" + "event=" + event + ", project=" + context.projectName() + ']';
+		return this.getClass().getSimpleName() + "[" + "event=" + event + ", projectGroup=" + context.projectGroupName()
+				+ ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraActionEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraActionEventHandler.java
@@ -1,8 +1,7 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler.action;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
-import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.reporting.FailureCollector;
 import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
@@ -12,9 +11,9 @@ public abstract class JiraActionEventHandler implements Runnable {
 
 	protected final JiraActionEvent event;
 	protected final FailureCollector failureCollector;
-	protected final HandlerProjectContext context;
+	protected final HandlerProjectGroupContext context;
 
-	protected JiraActionEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	protected JiraActionEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraActionEvent event) {
 		this.event = event;
 		this.failureCollector = FailureCollector.collector(reportingConfig);
@@ -36,10 +35,6 @@ public abstract class JiraActionEventHandler implements Runnable {
 			Log.infof("Finished processing %s. Pending events in %s to process: %s", this.toString(),
 					context.projectGroupName(), context.pendingDownstreamEventsInCurrentContext());
 		}
-	}
-
-	protected String toSourceKey(String key) {
-		return "%s-%d".formatted(context.project().originalProjectKey(), JiraIssue.keyToLong(key));
 	}
 
 	protected abstract void doRun();

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraAffectsVersionActionEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraAffectsVersionActionEventHandler.java
@@ -2,7 +2,7 @@ package org.hibernate.infra.replicate.jira.service.jira.handler.action;
 
 import java.util.List;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraVersion;
@@ -10,7 +10,7 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraAffectsVersionActionEventHandler extends JiraAbstractVersionActionEventHandler {
 
-	public JiraAffectsVersionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraAffectsVersionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraActionEvent event) {
 		super(reportingConfig, context, event);
 	}

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraAssigneeActionEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraAssigneeActionEventHandler.java
@@ -1,6 +1,6 @@
 package org.hibernate.infra.replicate.jira.service.jira.handler.action;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraUser;
@@ -8,7 +8,7 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraAssigneeActionEventHandler extends JiraActionEventHandler {
 
-	public JiraAssigneeActionEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraAssigneeActionEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraActionEvent event) {
 		super(reportingConfig, context, event);
 	}
@@ -29,12 +29,13 @@ public class JiraAssigneeActionEventHandler extends JiraActionEventHandler {
 			user = new JiraUser("-1");
 		}
 		if (user != null) {
-			context.sourceJiraClient().assign(toSourceKey(event.key), user);
+			context.sourceJiraClient().assign(context.contextForProject(event.projectKey).toSourceKey(event.key), user);
 		}
 	}
 
 	@Override
 	public String toString() {
-		return "JiraAssigneeActionEventHandler[" + "event=" + event + ", project=" + context.projectName() + ']';
+		return "JiraAssigneeActionEventHandler[" + "event=" + event + ", projectGroup=" + context.projectGroupName()
+				+ ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraFixVersionActionEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraFixVersionActionEventHandler.java
@@ -2,7 +2,7 @@ package org.hibernate.infra.replicate.jira.service.jira.handler.action;
 
 import java.util.List;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraVersion;
@@ -10,7 +10,7 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraFixVersionActionEventHandler extends JiraAbstractVersionActionEventHandler {
 
-	public JiraFixVersionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraFixVersionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraActionEvent event) {
 		super(reportingConfig, context, event);
 	}

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraTransitionActionEventHandler.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/handler/action/JiraTransitionActionEventHandler.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.handler.JiraStaticFieldMappingCache;
 import org.hibernate.infra.replicate.jira.service.jira.model.action.JiraActionEvent;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssue;
@@ -15,14 +15,14 @@ import org.hibernate.infra.replicate.jira.service.reporting.ReportingConfig;
 
 public class JiraTransitionActionEventHandler extends JiraActionEventHandler {
 
-	public JiraTransitionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectContext context,
+	public JiraTransitionActionEventHandler(ReportingConfig reportingConfig, HandlerProjectGroupContext context,
 			JiraActionEvent event) {
 		super(reportingConfig, context, event);
 	}
 
 	@Override
 	protected void doRun() {
-		String sourceKey = toSourceKey(event.key);
+		String sourceKey = context.contextForProject(event.projectKey).toSourceKey(event.key);
 		JiraIssue issue = context.destinationJiraClient().getIssue(event.key);
 		JiraIssue sourceIssue = context.sourceJiraClient().getIssue(sourceKey);
 
@@ -53,6 +53,7 @@ public class JiraTransitionActionEventHandler extends JiraActionEventHandler {
 
 	@Override
 	public String toString() {
-		return "JiraTransitionActionEventHandler[" + "event=" + event + ", project=" + context.projectName() + ']';
+		return "JiraTransitionActionEventHandler[" + "event=" + event + ", projectGroup=" + context.projectGroupName()
+				+ ']';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/action/JiraActionEvent.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/action/JiraActionEvent.java
@@ -8,6 +8,7 @@ import org.hibernate.infra.replicate.jira.service.jira.model.hook.JiraActionEven
 public class JiraActionEvent extends JiraBaseObject {
 	public String id;
 	public String key;
+	public String projectKey;
 	public String event;
 	public String assignee;
 	public String value;
@@ -20,7 +21,7 @@ public class JiraActionEvent extends JiraBaseObject {
 
 	@Override
 	public String toString() {
-		return "JiraActionEvent{" + "id='" + id + '\'' + ", key='" + key + '\'' + ", event='" + event + '\''
-				+ ", assignee='" + assignee + '\'' + ", value='" + value + '\'' + '}';
+		return "JiraActionEvent{" + "id='" + id + '\'' + ", key='" + key + '\'' + ", projectKey='" + projectKey + '\''
+				+ ", event='" + event + '\'' + ", assignee='" + assignee + '\'' + ", value='" + value + '\'' + '}';
 	}
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/hook/JiraActionEventType.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/hook/JiraActionEventType.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.handler.action.JiraAffectsVersionActionEventHandler;
 import org.hibernate.infra.replicate.jira.service.jira.handler.action.JiraAssigneeActionEventHandler;
 import org.hibernate.infra.replicate.jira.service.jira.handler.action.JiraFixVersionActionEventHandler;
@@ -17,7 +17,7 @@ public enum JiraActionEventType {
 	ISSUE_ASSIGNED("jira:issue_update_assignee") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraActionEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.assignee == null || event.key == null) {
 				throw new IllegalStateException(
 						"Trying to handle an issue event but issue id is null: %s".formatted(event));
@@ -28,21 +28,21 @@ public enum JiraActionEventType {
 	ISSUE_TRANSITIONED("jira:issue_update_status") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraActionEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			return List.of(new JiraTransitionActionEventHandler(reportingConfig, context, event));
 		}
 	},
 	FIX_VERSION_CHANGED("jira:issue_update_fixversion") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraActionEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			return List.of(new JiraFixVersionActionEventHandler(reportingConfig, context, event));
 		}
 	},
 	AFFECTS_VERSION_CHANGED("jira:issue_update_version") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraActionEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			return List.of(new JiraAffectsVersionActionEventHandler(reportingConfig, context, event));
 		}
 	};
@@ -70,5 +70,5 @@ public enum JiraActionEventType {
 	}
 
 	public abstract Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraActionEvent event,
-			HandlerProjectContext context);
+			HandlerProjectGroupContext context);
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/hook/JiraWebhookEventType.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/hook/JiraWebhookEventType.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
+import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.handler.JiraCommentDeleteEventHandler;
 import org.hibernate.infra.replicate.jira.service.jira.handler.JiraCommentUpsertEventHandler;
 import org.hibernate.infra.replicate.jira.service.jira.handler.JiraIssueDeleteEventHandler;
@@ -19,7 +19,7 @@ public enum JiraWebhookEventType {
 	ISSUE_CREATED("jira:issue_created") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.issue == null || event.issue.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle an issue event but issue id is null: %s".formatted(event));
@@ -30,7 +30,7 @@ public enum JiraWebhookEventType {
 	ISSUE_UPDATED("jira:issue_updated") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.issue == null || event.issue.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle an issue event but issue id is null: %s".formatted(event));
@@ -41,7 +41,7 @@ public enum JiraWebhookEventType {
 	ISSUE_DELETED("jira:issue_deleted") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.issue == null || event.issue.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle an issue event but issue id is null: %s".formatted(event));
@@ -52,7 +52,7 @@ public enum JiraWebhookEventType {
 	ISSUELINK_CREATED("issuelink_created") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.issueLink == null || event.issueLink.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle an issue link event but source issue id is null: %s".formatted(event));
@@ -65,7 +65,7 @@ public enum JiraWebhookEventType {
 	ISSUELINK_DELETED("issuelink_deleted") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.issueLink == null || event.issueLink.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle an issue link event but source issue id is null: %s".formatted(event));
@@ -80,7 +80,7 @@ public enum JiraWebhookEventType {
 	COMMENT_CREATED("comment_created") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.comment == null || event.comment.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle a comment event but comment id is null: %s".formatted(event));
@@ -96,7 +96,7 @@ public enum JiraWebhookEventType {
 	COMMENT_UPDATED("comment_updated") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.comment == null || event.comment.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle a comment event but comment id is null: %s".formatted(event));
@@ -112,7 +112,7 @@ public enum JiraWebhookEventType {
 	COMMENT_DELETED("comment_deleted") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.comment == null || event.comment.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle a comment event but comment id is null: %s".formatted(event));
@@ -124,7 +124,7 @@ public enum JiraWebhookEventType {
 	VERSION_CREATED("jira:version_created") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.version == null || event.version.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle a version event but version id is null: %s".formatted(event));
@@ -135,7 +135,7 @@ public enum JiraWebhookEventType {
 	VERSION_UPDATED("jira:version_updated") {
 		@Override
 		public Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-				HandlerProjectContext context) {
+				HandlerProjectGroupContext context) {
 			if (event.version == null || event.version.id == null) {
 				throw new IllegalStateException(
 						"Trying to handle a version event but version id is null: %s".formatted(event));
@@ -167,5 +167,5 @@ public enum JiraWebhookEventType {
 	}
 
 	public abstract Collection<Runnable> handlers(ReportingConfig reportingConfig, JiraWebHookEvent event,
-			HandlerProjectContext context);
+			HandlerProjectGroupContext context);
 }

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/rest/JiraFields.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/rest/JiraFields.java
@@ -13,7 +13,7 @@ public class JiraFields extends JiraBaseObject {
 	public String description;
 	public JiraSimpleObject priority = new JiraSimpleObject();
 	public JiraSimpleObject issuetype = new JiraSimpleObject();
-	public JiraSimpleObject project = new JiraSimpleObject();
+	public JiraProject project = new JiraProject();
 	public JiraSimpleObject status;
 	public List<String> labels;
 

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/rest/JiraProject.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/model/rest/JiraProject.java
@@ -1,0 +1,24 @@
+package org.hibernate.infra.replicate.jira.service.jira.model.rest;
+
+import java.net.URI;
+
+import org.hibernate.infra.replicate.jira.service.jira.model.JiraBaseObject;
+
+public class JiraProject extends JiraBaseObject {
+	public String id;
+	public String key;
+	public URI self;
+
+	public JiraProject() {
+	}
+
+	public JiraProject(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public String toString() {
+		return "JiraProject{" + "id=" + id + ", key='" + key + '\'' + ", self=" + self + "otherProperties="
+				+ properties() + '}';
+	}
+}

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/validation/ConfiguredProjectGroup.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/validation/ConfiguredProjectGroup.java
@@ -1,0 +1,28 @@
+package org.hibernate.infra.replicate.jira.service.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = {ConfiguredProjectGroupValidator.class})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+public @interface ConfiguredProjectGroup {
+	String message() default "The ${projectGroup} project group is not configured";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/validation/ConfiguredProjectGroupValidator.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/validation/ConfiguredProjectGroupValidator.java
@@ -1,0 +1,32 @@
+package org.hibernate.infra.replicate.jira.service.validation;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ConfiguredProjectGroupValidator implements ConstraintValidator<ConfiguredProjectGroup, String> {
+
+	@Inject
+	Instance<ConfiguredProjectsService> configuredProjectsService;
+
+	@Override
+	public void initialize(ConfiguredProjectGroup constraintAnnotation) {
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return true;
+		}
+		if (configuredProjectsService.get().isProjectGroup(value)) {
+			return true;
+		}
+
+		context.unwrap(HibernateConstraintValidatorContext.class).addExpressionVariable("projectGroup", value);
+
+		return false;
+	}
+}

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/validation/ConfiguredProjectsService.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/validation/ConfiguredProjectsService.java
@@ -13,12 +13,15 @@ public class ConfiguredProjectsService {
 
 	private final Set<String> upstreamProjects;
 	private final Set<String> downstreamProjects;
+	private final Set<String> projectGroups;
 
 	public ConfiguredProjectsService(JiraConfig jiraConfig) {
 		Set<String> down = new HashSet<>();
 		Set<String> up = new HashSet<>();
-		for (JiraConfig.JiraProjectGroup group : jiraConfig.projectGroup().values()) {
-			for (JiraConfig.JiraProject project : group.projects().values()) {
+		Set<String> groups = new HashSet<>();
+		for (var group : jiraConfig.projectGroup().entrySet()) {
+			groups.add(group.getKey());
+			for (JiraConfig.JiraProject project : group.getValue().projects().values()) {
 				up.add(project.originalProjectKey());
 				down.add(project.projectKey());
 			}
@@ -26,6 +29,7 @@ public class ConfiguredProjectsService {
 
 		upstreamProjects = Collections.unmodifiableSet(up);
 		downstreamProjects = Collections.unmodifiableSet(down);
+		projectGroups = Collections.unmodifiableSet(groups);
 	}
 
 	public boolean isUpstreamProject(String projectName) {
@@ -34,5 +38,9 @@ public class ConfiguredProjectsService {
 
 	public boolean isDownstreamProject(String projectName) {
 		return downstreamProjects.contains(projectName);
+	}
+
+	public boolean isProjectGroup(String value) {
+		return projectGroups.contains(value);
 	}
 }

--- a/src/test/java/org/hibernate/infra/replicate/jira/SimpleProjectHookTest.java
+++ b/src/test/java/org/hibernate/infra/replicate/jira/SimpleProjectHookTest.java
@@ -33,22 +33,23 @@ class SimpleProjectHookTest {
 
 	@Test
 	void unknown() {
-		given().when().body(REQUEST_BODY).contentType(ContentType.JSON).post("api/jira/webhooks/NOTAPROJECTKEY").then()
-				.statusCode(400).body(containsString("The NOTAPROJECTKEY project is not configured"));
+		given().when().body(REQUEST_BODY).contentType(ContentType.JSON)
+				.post("api/jira/webhooks/source/NOTAPROJECTGROUPKEY").then().statusCode(400)
+				.body(containsString("The NOTAPROJECTGROUPKEY project group is not configured"));
 	}
 
 	@Test
 	void known() {
 		given().when().body(REQUEST_BODY)
 				.header("x-hub-signature", RequestSignatureFilter.sign("not-a-secret", REQUEST_BODY))
-				.contentType(ContentType.JSON).post("api/jira/webhooks/JIRATEST1").then().statusCode(200)
+				.contentType(ContentType.JSON).post("api/jira/webhooks/source/hibernate").then().statusCode(200)
 				.body(is("ack"));
 	}
 
 	@Test
 	void knownNoHeader() {
-		given().when().body(REQUEST_BODY).contentType(ContentType.JSON).post("api/jira/webhooks/JIRATEST1").then()
-				.statusCode(401);
+		given().when().body(REQUEST_BODY).contentType(ContentType.JSON).post("api/jira/webhooks/source/hibernate")
+				.then().statusCode(401);
 	}
 
 }

--- a/src/test/java/org/hibernate/infra/replicate/jira/export/ExportProjectTest.java
+++ b/src/test/java/org/hibernate/infra/replicate/jira/export/ExportProjectTest.java
@@ -124,7 +124,7 @@ class ExportProjectTest {
 					row.add(issueTypeMap.getOrDefault(issue.fields.issuetype.name, ""));
 					row.add(statusMap.getOrDefault(issue.fields.status.name, ""));
 					row.add(issue.fields.project.properties().get("key"));
-					row.add(issue.fields.project.name);
+					row.add(issue.fields.project.properties().get("name"));
 					Object reporter = issue.fields.reporter == null
 							? null
 							: projectGroup.users().mapping().getOrDefault(issue.fields.reporter.accountId, null);

--- a/src/test/java/org/hibernate/infra/replicate/jira/handler/IssueTest.java
+++ b/src/test/java/org/hibernate/infra/replicate/jira/handler/IssueTest.java
@@ -4,12 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.hibernate.infra.replicate.jira.JiraConfig;
 import org.hibernate.infra.replicate.jira.mock.SampleJiraRestClient;
-import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectContext;
 import org.hibernate.infra.replicate.jira.service.jira.HandlerProjectGroupContext;
 import org.hibernate.infra.replicate.jira.service.jira.handler.JiraCommentDeleteEventHandler;
 import org.hibernate.infra.replicate.jira.service.jira.handler.JiraCommentUpsertEventHandler;
@@ -45,18 +41,12 @@ class IssueTest {
 	@Inject
 	JiraConfig jiraConfig;
 
-	HandlerProjectContext context;
+	HandlerProjectGroupContext context;
 
 	@BeforeEach
 	void setUp() {
-		Map<String, HandlerProjectContext> contextMap = new HashMap<>();
-		HandlerProjectGroupContext projectGroupContext = new HandlerProjectGroupContext(
-				jiraConfig.projectGroup().get(PROJECT_GROUP_NAME));
-		context = new HandlerProjectContext("JIRATEST1", PROJECT_GROUP_NAME, source, destination, projectGroupContext,
-				contextMap);
-		contextMap.put("JIRATEST1", context);
-		contextMap.put("JIRATEST2", new HandlerProjectContext("JIRATEST2", PROJECT_GROUP_NAME, source, destination,
-				projectGroupContext, contextMap));
+		context = new HandlerProjectGroupContext(PROJECT_GROUP_NAME, jiraConfig.projectGroup().get(PROJECT_GROUP_NAME),
+				source, destination);
 	}
 
 	@AfterEach

--- a/src/test/java/org/hibernate/infra/replicate/jira/mock/SampleJiraRestClient.java
+++ b/src/test/java/org/hibernate/infra/replicate/jira/mock/SampleJiraRestClient.java
@@ -21,6 +21,7 @@ import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueLinkT
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueResponse;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssueTransition;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraIssues;
+import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraProject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraRemoteLink;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraSimpleObject;
 import org.hibernate.infra.replicate.jira.service.jira.model.rest.JiraTransition;
@@ -232,6 +233,14 @@ public class SampleJiraRestClient implements JiraRestClient {
 	@Override
 	public void assign(String id, JiraUser assignee) {
 		// ok
+	}
+
+	@Override
+	public JiraProject project(String projectId) {
+		JiraProject project = new JiraProject();
+		project.id = projectId;
+		project.key = "JIRATEST1";
+		return project;
 	}
 
 	private JiraIssueLink sampleIssueLink(Long id) {

--- a/src/test/java/org/hibernate/infra/replicate/jira/service/validation/RequestSignatureFilterTest.java
+++ b/src/test/java/org/hibernate/infra/replicate/jira/service/validation/RequestSignatureFilterTest.java
@@ -24,19 +24,21 @@ class RequestSignatureFilterTest {
 		RequestSignatureFilter filter = createFilter(true, "wrong-secret");
 
 		assertThat(filter.checkSignature(requestContext("/path-not-matching-the-pattern"))).isNull();
-		assertThat(filter.checkSignature(requestContext("/jira/webhooks/UNKNOWN"))).isNull();
-		assertThat(filter.checkSignature(requestContext("/jira/webhooks/UNKNOWN", "POST", "smth"))).isNull();
+		assertThat(filter.checkSignature(requestContext("/jira/webhooks/source/UNKNOWN"))).isNull();
+		assertThat(filter.checkSignature(requestContext("/jira/webhooks/source/UNKNOWN", "POST", "smth"))).isNull();
 
-		Response response = filter.checkSignature(requestContext("/jira/webhooks/PROJECT_KEY", "POST", "smth"));
+		Response response = filter
+				.checkSignature(requestContext("/jira/webhooks/source/PROJECT_GROUP_KEY", "POST", "smth"));
 		assertThat(response).isNotNull();
 		assertThat((String) response.getEntity()).contains("Missing x-hub-signature header");
 
-		response = filter.checkSignature(
-				requestContext("/jira/webhooks/PROJECT_KEY", "POST", "smth", Map.of("x-hub-signature", "smth-wrong")));
+		response = filter.checkSignature(requestContext("/jira/webhooks/source/PROJECT_GROUP_KEY", "POST", "smth",
+				Map.of("x-hub-signature", "smth-wrong")));
 		assertThat(response).isNotNull();
 		assertThat((String) response.getEntity()).contains("Signatures do not match");
 
-		ContainerRequestContext requestContext = requestContext("/jira/webhooks/PROJECT_KEY", "POST", "smth",
+		ContainerRequestContext requestContext = requestContext("/jira/webhooks/source/PROJECT_GROUP_KEY", "POST",
+				"smth",
 				Map.of("x-hub-signature", "sha256=beb656dd03b5a81bee94aab4966943bf694929fcd359c45a1947277df2541a5d"));
 		assertThat(filter.checkSignature(requestContext)).isNull();
 		Mockito.verify(requestContext, Mockito.times(1)).setEntityStream(Mockito.any());
@@ -85,7 +87,7 @@ class RequestSignatureFilterTest {
 				return Type.SIGNATURE;
 			}
 		};
-		Mockito.when(project.security()).thenReturn(value);
+		Mockito.when(group.security()).thenReturn(value);
 		Mockito.when(project.downstreamSecurity()).thenReturn(value);
 
 		Mockito.when(group.projects()).thenReturn(Map.of("PROJECT_KEY", project));

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -17,14 +17,12 @@ jira.project-group."hibernate".issue-link-types.default-value=10050
 
 jira.project-group."hibernate".statuses.mapping."to\u0020do"=to do
 
-jira.project-group."hibernate".projects.JIRATEST1.security.secret=not-a-secret
+jira.project-group."hibernate".security.secret=not-a-secret
+jira.project-group."hibernate".security.enabled=true
 jira.project-group."hibernate".projects.JIRATEST1.project-id=10323
 jira.project-group."hibernate".projects.JIRATEST1.project-key=JIRATEST2
 jira.project-group."hibernate".projects.JIRATEST1.original-project-key=JIRATEST1
-jira.project-group."hibernate".projects.JIRATEST1.security.enabled=true
 
-jira.project-group."hibernate".projects.JIRATEST2.security.secret=not-a-secret
 jira.project-group."hibernate".projects.JIRATEST2.project-id=10324
 jira.project-group."hibernate".projects.JIRATEST2.project-key=JIRATEST2
 jira.project-group."hibernate".projects.JIRATEST2.original-project-key=JIRATEST2
-jira.project-group."hibernate".projects.JIRATEST2.security.enabled=true


### PR DESCRIPTION
instead of a project context and remove dependency on the project key in the requests.