### PR TITLE
Allow explicit mapping of downstream -> upstream statuses

### DIFF
--- a/src/main/java/org/hibernate/infra/replicate/jira/JiraConfig.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/JiraConfig.java
@@ -59,6 +59,12 @@ public interface JiraConfig {
 		StatusesValueMapping statuses();
 
 		/**
+		 * Same as {@link #statuses()}, but to map downstream statuses to upstream one
+		 * for the backwards sync.
+		 */
+		Optional<StatusesValueMapping> downstreamStatuses();
+
+		/**
 		 * Mapping of upstream issue types to downstream ones. Please make sure to
 		 * review your project scheme to see which issue types are available.
 		 */

--- a/src/main/java/org/hibernate/infra/replicate/jira/service/jira/HandlerProjectGroupContext.java
+++ b/src/main/java/org/hibernate/infra/replicate/jira/service/jira/HandlerProjectGroupContext.java
@@ -72,7 +72,10 @@ public final class HandlerProjectGroupContext implements AutoCloseable {
 				TimeUnit.MILLISECONDS, downstreamWorkQueue);
 
 		this.invertedUsers = invert(projectGroup.users().mapping());
-		this.invertedStatuses = invert(projectGroup.statuses().mapping());
+		// use the explicit config if present, but fallback to the inverted map
+		// otherwise.
+		this.invertedStatuses = projectGroup.downstreamStatuses().map(JiraConfig.ValueMapping::mapping)
+				.orElseGet(() -> invert(projectGroup.statuses().mapping()));
 		this.sourceJiraClient = source;
 		this.destinationJiraClient = destination;
 


### PR DESCRIPTION
for better handling of the transition sync